### PR TITLE
Remove public key requirement to decrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Use the -l parameter to pass in a label for the encrypted value,
 
 ### Decryption
 
-To decrypt something, you need the public_key and the private_key.
+To decrypt something, you need the private_key.
 
 To test decryption you can also use the eyaml tool if you have both keys
 

--- a/lib/hiera/backend/eyaml/encryptors/pkcs7.rb
+++ b/lib/hiera/backend/eyaml/encryptors/pkcs7.rb
@@ -49,10 +49,12 @@ class Hiera
             private_key_pem = load_private_key_pem
             private_key_rsa = OpenSSL::PKey::RSA.new(private_key_pem)
 
-            public_key_pem = load_public_key_pem
-            public_key_x509 = OpenSSL::X509::Certificate.new(public_key_pem)
-
             pkcs7 = OpenSSL::PKCS7.new(ciphertext)
+
+            public_key_x509 = OpenSSL::X509::Certificate.new
+            public_key_x509.serial = pkcs7.recipients[0].serial
+            public_key_x509.public_key = private_key_rsa.public_key
+
             pkcs7.decrypt(private_key_rsa, public_key_x509)
           end
 


### PR DESCRIPTION
OpenSSL::PKCS7.decrypt validates the recipient by comparing the serial number of the recipient certificate with the one bundled with the data. It also makes sure the public keys match. Since, the serial number is bundled with the data and the public key is bundled with the private key, we can generate on the fly a certificate object that satisfies PKCS7.decrypt and return the plain text.