### PR TITLE
Add support to encrypt with an RSA public key

### DIFF
--- a/lib/hiera/backend/eyaml/encryptors/pkcs7.rb
+++ b/lib/hiera/backend/eyaml/encryptors/pkcs7.rb
@@ -37,7 +37,13 @@ class Hiera
             LoggingHelper.trace 'PKCS7 encrypt'
 
             public_key_pem = load_public_key_pem
-            public_key_x509 = OpenSSL::X509::Certificate.new(public_key_pem)
+            if public_key_pem.include? 'BEGIN CERTIFICATE'
+              public_key_x509 = OpenSSL::X509::Certificate.new(public_key_pem)
+            elsif public_key_pem.include? 'BEGIN PUBLIC KEY'
+              public_key_rsa = OpenSSL::PKey::RSA.new(public_key_pem)
+              public_key_x509 = OpenSSL::X509::Certificate.new
+              public_key_x509.public_key = public_key_rsa.public_key
+            end
 
             cipher = OpenSSL::Cipher.new('aes-256-cbc')
             OpenSSL::PKCS7.encrypt([public_key_x509], plaintext, cipher, OpenSSL::PKCS7::BINARY).to_der


### PR DESCRIPTION
Based on the header of the public key, we can identify if we have a X509 certificate or an RSA public key. If we have an RSA public key, we simply generate a X509 certificate on the fly that will contain only the information required by encrypt.